### PR TITLE
Update docstring in extract_tidegauge()

### DIFF
--- a/src/momlevel/tidegauge.py
+++ b/src/momlevel/tidegauge.py
@@ -68,8 +68,9 @@ def extract_tidegauge(
         Wet mask on model grid (1=ocean, 0=land)
     threshold : float, optional
         Filter locations that are insufficiently close to a model
-        grid point. A value of 1 to 1.5 of the model's nominal
-        resolution is a suggested value, by default None
+        grid point. The threshold value represents the maximum allowed distance in km. 
+        A value of 1 to 1.5 of the model's nominal resolution is a suggested value,
+        by default None
     disable_warning : bool, optional
         Disable warnings when a requested point cannot be mapped. This
         option is set to True by default as requesting tide gauge locations


### PR DESCRIPTION
This commit updates the docstring of extract_tidegauge() to add the necessary information that the threshold is in km. This should address issue #38.