### PR TITLE
Optional top and bottom parameters to `calc_dz()`

### DIFF
--- a/src/momlevel/derived.py
+++ b/src/momlevel/derived.py
@@ -253,7 +253,7 @@ def calc_dz(levels, interfaces, depth, top=0.0, bottom=None, fraction=False):
     coordinate levels and interfaces to calculate a 3-dimensional
     dz field that properly accounts for partial bottom cells.
 
-    A specific depth range and be provided using the `top` and `bottom`
+    A specific depth range can be provided using the `top` and `bottom`
     arguments to request dz over a specified depth range.
 
     Parameters

--- a/tests/test_derived.py
+++ b/tests/test_derived.py
@@ -42,7 +42,7 @@ def test_calc_dz_3():
 
 def test_calc_dz_4():
     dz = derived.calc_dz(dset2.z_l, dset2.z_i, dset2.deptho, top=12., bottom=33.)
-    assert np.allclose(dz.sum(), 441.84425447)
+    assert np.allclose(dz.sum(), 363.71725794)
 
 
 def test_calc_rho():

--- a/tests/test_derived.py
+++ b/tests/test_derived.py
@@ -40,6 +40,11 @@ def test_calc_dz_3():
         derived.calc_dz(dset2.z_l, dset2.z_i, deptho)
 
 
+def test_calc_dz_4():
+    dz = derived.calc_dz(dset2.z_l, dset2.z_i, dset2.deptho, top=12., bottom=33.)
+    assert np.allclose(dz.sum(), 441.84425447)
+
+
 def test_calc_rho():
     rho = derived.calc_rho(dset1.thetao, dset1.so, dset1.z_l * 1.0e4, eos="Wright")
     pytest.rho = rho


### PR DESCRIPTION
The `calc_dz()` function is extended to have top and bottom parameters. These allow the partial weights to be returned where the specified top and bottom levels intersect the vertical z-level coordinate.  This is useful when calculating a precise depth range sum or average, such as 0 to 700 m, that may not align exactly with the model's z-level bounds.