### PR TITLE
New function `momlevel.trend.deseason` that supports both dask arrays and in-memory numpy arrays

### DIFF
--- a/src/momlevel/trend.py
+++ b/src/momlevel/trend.py
@@ -1,8 +1,10 @@
 """ trend.py - utilities for working with trends """
 
 import warnings
+import cftime
 import numpy as np
 import xarray as xr
+
 
 __all__ = [
     "broadcast_trend",
@@ -10,6 +12,7 @@ __all__ = [
     "linear_detrend",
     "time_conversion_factor",
     "seasonal_model",
+    "deseason",
 ]
 
 
@@ -445,3 +448,398 @@ def seasonal_model(da_timeseries, tcoord="time", return_model=False):
     if return_model:
         return smodel, residuals
     return residuals
+
+
+def seasonal_cycle_model(ts, daysinyear=365.0, tdim="time"):
+    """
+    Fits a seasonal cycle model to a given 1D time series.
+
+    This function models the input time series `ts` as the sum of a linear trend,
+    annual and semi-annual harmonics, and a residual term. It calculates fitted
+    coefficients for the model parameters and returns them along with the residuals
+    and the modeled time series.
+
+    Parameters
+    ----------
+    ts : numpy.ndarray
+        Input 1D time series to which the seasonal cycle model is fitted.
+    daysinyear : int or float, optional
+        Number of days in a year used to normalize the time series. Defaults to 365.0.
+    tdim : str, optional
+        Dimension label for time, not explicitly used in the computation. Defaults to
+        "time".
+
+    Returns
+    -------
+    mcoeff : numpy.ndarray
+        Array of shape (6,) containing the fitted coefficients for the model:
+        [a0, a1, b1, b2, c1, c2], where:
+        - a0: intercept,
+        - a1: linear trend coefficient,
+        - b1, b2: coefficients for the annual harmonic,
+        - c1, c2: coefficients for the semi-annual harmonic.
+    residuals : numpy.ndarray
+        Array of the same shape as `ts`, representing the difference between the
+        input time series and the modeled series.
+    smodel : numpy.ndarray
+        Array of the same shape as `ts`, containing the modeled time series based on
+        the seasonal cycle model.
+    """
+
+    time_length = ts.shape[0]
+    if isinstance(daysinyear, float) or isinstance(daysinyear, int):
+        time_dec = np.arange(time_length) / 365.0
+    else:
+        time_dec = np.arange(time_length) / daysinyear
+
+    assert len(ts) == len(
+        time_dec
+    ), f"Chunk timeseries len is {len(ts)} but daysinyear is {len(time_dec)}"
+
+    # Construct the model matrix
+    model = np.array(
+        [
+            np.ones(time_length),
+            time_dec - np.mean(time_dec),
+            np.sin(2 * np.pi * time_dec),
+            np.cos(2 * np.pi * time_dec),
+            np.sin(4 * np.pi * time_dec),
+            np.cos(4 * np.pi * time_dec),
+        ]
+    )
+
+    # Compute pseudoinverse
+    pmodel = np.linalg.pinv(model)
+
+    # Coefficients
+    mcoeff = np.dot(ts, pmodel)
+
+    # Seasonal/trend model
+    smodel = np.dot(mcoeff, model)
+
+    # Residuals
+    residuals = ts - smodel
+
+    return mcoeff, residuals, smodel
+
+
+def _detrend_deseason_chunk(chunk, axis=-1, daysinyear=365, output_format="residuals"):
+    """
+    Process a chunk of data and remove trends and seasonal patterns. The output could
+    be the detrended residuals, the seasonal model, or the model coefficients,
+    based on the specified output format.
+
+    Parameters
+    ----------
+    chunk : ndarray
+        Multidimensional data array where the detrending and deseasonalizing
+        operations will take place. The input should follow the axis distribution
+        specified by the `axis` parameter.
+
+    axis : int, default=-1
+        The axis along which the operations (trend and seasonal cycle removal)
+        are applied. Typically, this corresponds to the time dimension.
+
+    daysinyear : int, default=365
+        Number of days in a year used to compute the seasonal cycle. This parameter
+        should match the temporal resolution of the data (e.g., if using a 365-day
+        (noleap) calendar, `daysinyear` should be set to 365).
+
+    output_format : str, default="residuals"
+        Specifies the output type. Can be one of:
+        - "residuals": Returns detrended and deseasonalized residuals.
+        - "model": Returns the seasonal and trend model itself.
+        - "coeff": Returns the coefficients of the model fit instead.
+
+    Returns
+    -------
+    ndarray or None
+        Depending on the `output_format`, the output is a numpy array containing
+        residuals, seasonal/trend model, or model coefficients. The shape of the
+        result depends on the input and output format:
+        - "residuals" or "model": Same shape as the input `chunk`.
+        - "coeff": If `chunk` is 3D or higher, appends an additional dimension for
+          coefficients (e.g., shape becomes `(chunk.shape[:-1], 6)`).
+
+    Raises
+    ------
+    ValueError
+        If `output_format` is not one of ["residuals", "model", "coeff"].
+    """
+
+    def func(ts, daysinyear=365, output_format="residuals"):
+        mcoeff, residuals, smodel = seasonal_cycle_model(ts, daysinyear=daysinyear)
+
+        if output_format == "residuals":
+            result = residuals
+        elif output_format == "model":
+            result = smodel
+        elif output_format == "coeff":
+            # For coefficients, just return the coefficients themselves
+            result = mcoeff
+        else:
+            raise ValueError(f"output_format {output_format} not recognized")
+
+        return result
+
+    # For coefficients, we need special handling
+    if output_format == "coeff":
+        # Reshape the chunk to 2D: (spatial_points, time)
+        original_shape = chunk.shape
+        n_spatial_points = np.prod(original_shape[:-1])
+        chunk_2d = chunk.reshape(n_spatial_points, original_shape[-1])
+
+        # Apply the function to each spatial point
+        results = np.array(
+            [
+                func(ts, daysinyear=daysinyear, output_format=output_format)
+                for ts in chunk_2d
+            ]
+        )
+
+        # Reshape back to original spatial dimensions plus coefficients
+        return results.reshape(original_shape[:-1] + (6,))
+    else:
+        return np.apply_along_axis(
+            func, axis, chunk, daysinyear=daysinyear, output_format=output_format
+        )
+
+
+def _detrend_deseason_lazy(arr, daysinyear=365, output_format="residuals"):
+    """
+    Remove trend and seasonal components from time-series data in a lazy computation manner.
+
+    This function applies a detrending and deseasoning operation to an input time-series
+    dataset using lazy computation, which is suitable for out-of-core operations on
+    chunked arrays. The time dimension is processed to remove linear trends and seasonality.
+    The resulting dataset can either contain residuals or the coefficients of the linear
+    model used for detrending and deseasoning.
+
+    Parameters
+    ----------
+    arr : dask.array.Array
+        The input time-series dataset, where the last dimension is assumed to be time.
+    daysinyear : int, optional
+        The number of days in a complete year to account for seasonal periodicity. Defaults
+        to 365.
+    output_format : str, optional
+        Determines the format of the output. If "residuals," the function returns the
+        deseasoned and detrended residuals. If "coeff," the function returns the coefficients
+        of the detrending and deseasoning model instead.
+
+    Returns
+    -------
+    dask.array.Array
+        A new dask array with the same type as the input where the detrending and
+        deseasoning operation has been applied. The output dimensions depend on the value
+        of the `output_format` parameter:
+        - If output_format is "residuals," the dimensions of the output array will match
+          the input.
+        - If output_format is "coeff," the last dimension will be replaced with a length-6
+          dimension for the coefficients.
+
+    Raises
+    ------
+    ValueError
+        Raised if the `output_format` specified is not "residuals" or "coeff".
+    """
+
+    nchunks = len(arr.chunks)
+    depth = {nchunks - 1: 0}
+
+    # For coefficients, we need to adjust the output chunks
+    if output_format == "coeff":
+        # The output will have 6 coefficients instead of the time dimension
+        new_chunks = list(arr.chunks[:-1])  # All chunks except time
+        new_chunks.append((6,))  # Add chunk for coefficients
+        meta = np.array([], dtype=arr.dtype)
+    else:
+        new_chunks = arr.chunks
+        meta = None
+
+    return arr.map_overlap(
+        _detrend_deseason_chunk,
+        depth=depth,
+        boundary="none",
+        dtype=arr.dtype,
+        chunks=new_chunks,
+        meta=meta,
+        daysinyear=daysinyear,
+        output_format=output_format,
+    )
+
+
+def deseason(arr, tdim="time", output_format="residuals"):
+    """
+    Removes seasonal and linear trends from a time-series dataset.
+
+    This function applies detrending and deseasonalizing operations on
+    an `xarray.DataArray` object. It can return residuals, the fitted
+    model, or the model coefficients based on the specified `output_format`.
+    The input array is processed along a specified time dimension, and the
+    output array maintains the same shape as the input in all configurations
+    except for coefficient mode.
+
+    The model equation is:
+
+    .. math::
+        y(t) = a_0 + a_1t + b_1\sin(2\pi t) + b_2\cos(2\pi t) + c_1\sin(4\pi t) + c_2\cos(4\pi t) + \epsilon(t)
+
+    where:
+    - :math:`t` is time in decimal years
+    - :math:`a_0` is the constant term (mean)
+    - :math:`a_1` is the linear trend coefficient
+    - :math:`b_1, b_2` are the annual cycle coefficients
+    - :math:`c_1, c_2` are the semi-annual cycle coefficients
+    - :math:`\epsilon(t)` represents the residuals
+
+    The annual cycle amplitude and phase can be computed from the coefficients as:
+    .. math::
+        A_{annual} = \sqrt{b_1^2 + b_2^2}
+        \phi_{annual} = \arctan2(b_2, b_1)
+
+    Parameters
+    ----------
+    arr : xr.DataArray
+        Input data as an `xarray.DataArray` object. The data should have a
+        time dimension specified by `tdim`. If no chunking is applied to
+        the array along the time dimension, it will be rechunked.
+    tdim : str, default="time"
+        The name of the time dimension in `arr` along which the
+        computation will be performed. The default value is "time".
+    output_format : {"residuals", "model", "coeff"}, default="residuals"
+        Specifies the type of output to return:
+        - "residuals": Returns the daily residuals after detrending and
+          removing seasonal signals.
+        - "model": Returns the linear trend and seasonal cycle model.
+        - "coeff": Returns the polynomial coefficients of the fitted
+          seasonal model.
+
+    Returns
+    -------
+    xr.DataArray
+        The processed `xarray.DataArray` after removing trends and
+        seasonal components. The exact contents will depend on the
+        selected `output_format`.
+
+    """
+
+    # Apply the detrending and deseasonalizing, returning residuals.
+    # The output array will have the same dimensions as `da`.
+
+    # this function only works on xarray DataArray objects
+    assert isinstance(arr, xr.DataArray), "Input must be an xarray DataArray"
+
+    # store array attributes for reassignment at the end
+    attrs = arr.attrs
+
+    # check that the specified time dimension exists
+    core_dims = list(arr.dims)
+    assert tdim in core_dims, (
+        f"Core dim {tdim} not found. " + "Specify alternate with tdim option."
+    )
+
+    # prepare chunking structure for input array
+    keep_lazy = True
+    chunks = arr.chunks
+    if chunks is None:
+        # chunk along the time dimension to convert to dask array
+        arr = arr.chunk({tdim: len(arr[tdim])})
+        keep_lazy = False
+    else:
+        # the dask array must have a continuous chunk along the time dimension, otherwise
+        # the model will fit each chunk independently and not the entire array
+
+        # determine where the time index sits in the dimension ordering
+        tdim_position = core_dims.index(tdim)
+
+        # rechunk the time dimension, if needed
+        if len(chunks[tdim_position]) != 1:
+            arr = arr.chunk({tdim: len(arr[tdim])})
+
+    # determine an array of the days in a year
+    daysinyear = np.array(
+        [
+            366 if x is True else 365
+            for x in [
+                cftime.is_leap_year(x.year, x.calendar) for x in list(arr.time.values)
+            ]
+        ]
+    )
+
+    # reorder the dimensions so that the time dimension is the last in the list
+    if tdim in core_dims:
+        core_dims.remove(tdim)
+        core_dims.append(tdim)
+    else:
+        raise ValueError(
+            f"Core dimension '{tdim}' not found in array. Specify alternate with tdim option."
+        )
+
+    # set output core dims based on the mode
+    if output_format in ["residuals", "model"]:
+        output_dims = core_dims
+    elif output_format == "coeff":
+        # Replace time dimension with coefficient dimension
+        output_dims = core_dims[:-1] + ["coeff"]
+        coeff_coords = [
+            "constant",
+            "trend",
+            "sin_annual",
+            "cos_annual",
+            "sin_semiannual",
+            "cos_semiannual",
+        ]
+    else:
+        raise ValueError(f"output_format {output_format} not recognized")
+
+    # cast output dimensions as a tuple
+    output_dims = tuple(output_dims)
+
+    # call the core calculation routines
+    result = xr.apply_ufunc(
+        _detrend_deseason_lazy,
+        arr,
+        kwargs={"daysinyear": daysinyear, "output_format": output_format},
+        input_core_dims=[core_dims],
+        output_core_dims=[output_dims],
+        dask="allowed",
+    )
+
+    # transpose dimensions of the result
+    if output_format == "coeff":
+        result = result.assign_coords(coeff=coeff_coords)
+        result = result.transpose("coeff", ...)
+    else:
+        result = result.transpose("time", ...)
+
+    # Calculate if original input array was not a dask array
+    if keep_lazy is False:
+        result = result.load()
+
+    # update attribute values based on mode
+    attrs.pop("standard_name", None)
+    if output_format == "residuals":
+        if "long_name" in attrs.keys():
+            attrs["long_name"] = (
+                attrs["long_name"] + " residuals from detrending and deseasonalizing"
+            )
+        attrs["processing"] = "Residuals from detrending and deseasonalizing"
+    elif output_format == "model":
+        if "long_name" in attrs.keys():
+            attrs["long_name"] = (
+                attrs["long_name"] + " model of linear trend and seasonal cycle"
+            )
+        attrs["processing"] = "Model of linear trend and seasonal cycle"
+    elif output_format == "coeff":
+        if "long_name" in attrs.keys():
+            attrs["long_name"] = (
+                attrs["long_name"] + " seasonal model polynomial coefficients"
+            )
+        attrs["processing"] = "Seasonal model polynomial coefficients"
+        attrs.pop("units", None)
+
+    # reassign attributes
+    result.attrs = attrs
+
+    return result


### PR DESCRIPTION
- Introduced a new function `momlevel.trend.deseason` that is based on the existing `seasonal_model` code
- New code supports both dask arrays and in-memory numpy arrays
- Options to return the fitted model, residuals from the model, and the coefficients of the model