### PR TITLE
Added function to alphabetize xarray datasets

### DIFF
--- a/src/momlevel/util.py
+++ b/src/momlevel/util.py
@@ -11,6 +11,7 @@ from momlevel import eos
 from momlevel import trend
 
 __all__ = [
+    "alphabetize_dataset",
     "annual_average",
     "annual_cycle",
     "default_coords",
@@ -26,6 +27,23 @@ __all__ = [
     "validate_dataset",
     "validate_tidegauge_data",
 ]
+
+
+def alphabetize_dataset(ds):
+    """This function reorders the variables in an xarray dataset
+    according to alphabetical order
+
+    Parameters
+    ----------
+    ds : xarray.core.dataset.Dataset
+        Input xarray datset
+
+    Returns
+    -------
+    xarray.core.dataset.Dataset
+    """
+
+    return ds[sorted(ds.variables.keys())]
 
 
 def annual_average(xobj, tcoord="time"):


### PR DESCRIPTION
Variables within an xarray datasets are not guaranteed to be in any particular dataset. This can be problematic for datasets with many variables. This commit adds a function to alphabetize the variable names in a dataset.