### PR TITLE
Fix/alternate var names

### DIFF
--- a/src/momlevel/steric.py
+++ b/src/momlevel/steric.py
@@ -117,28 +117,28 @@ def steric(
             thetao = dset["thetao"]
         else:
             thetao = dset["temp"]
-        if "so" in dset:
+        if "so" in reference:
             so = reference["so"]
         else:
             so = reference["salt"]
     elif variant == "halosteric":
-        if "thetao" in dset:
-            thetao = dset["thetao"]
+        if "thetao" in reference:
+            thetao = reference["thetao"]
         else:
-            thetao = dset["temp"]
+            thetao = reference["temp"]
         if "so" in dset:
-            so = reference["so"]
+            so = dset["so"]
         else:
-            so = reference["salt"]
+            so = dset["salt"]
     elif variant == "steric":
         if "thetao" in dset:
             thetao = dset["thetao"]
         else:
             thetao = dset["temp"]
         if "so" in dset:
-            so = reference["so"]
+            so = dset["so"]
         else:
-            so = reference["salt"]
+            so = dset["salt"]
     else:
         raise ValueError(f"Unknown variant '{variant}' passed to `steric`")
 

--- a/src/momlevel/steric.py
+++ b/src/momlevel/steric.py
@@ -113,14 +113,32 @@ def steric(
 
     # determine which fields, if any, to hold fixed
     if variant == "thermosteric":
-        thetao = dset["thetao"]
-        so = reference["so"]
+        if "thetao" in dset:
+            thetao = dset["thetao"]
+        else:
+            thetao = dset["temp"]
+        if "so" in dset:
+            so = reference["so"]
+        else:
+            so = reference["salt"]
     elif variant == "halosteric":
-        thetao = reference["thetao"]
-        so = dset["so"]
+        if "thetao" in dset:
+            thetao = dset["thetao"]
+        else:
+            thetao = dset["temp"]
+        if "so" in dset:
+            so = reference["so"]
+        else:
+            so = reference["salt"]
     elif variant == "steric":
-        thetao = dset["thetao"]
-        so = dset["so"]
+        if "thetao" in dset:
+            thetao = dset["thetao"]
+        else:
+            thetao = dset["temp"]
+        if "so" in dset:
+            so = reference["so"]
+        else:
+            so = reference["salt"]
     else:
         raise ValueError(f"Unknown variant '{variant}' passed to `steric`")
 


### PR DESCRIPTION
Added if-else statements to check whether "thetao" and "so" exist in the datasets. If not, assumes variables are stored as "temp" and "salt". (Allows for using momlevel to analyze output from older MOM6 versions.) Similar changes must be made to other functions (including reference.py and util.py). Perhaps there's a better solution than making every function check for thetao/temp and so/salt.